### PR TITLE
Bug fixed for Gnome crashes after leaving full screen

### DIFF
--- a/Flat-Remix-dark-miami/gnome-shell/gnome-shell.css
+++ b/Flat-Remix-dark-miami/gnome-shell/gnome-shell.css
@@ -717,9 +717,7 @@ app menu inside the main app window itself rather than the top bar
       -st-icon-style: symbolic;
       margin-left: 4px;
       margin-right: 4px; }
-    #panel .panel-button .system-status-icon,
-    #panel .panel-button .app-menu-icon > StIcon,
-    #panel .panel-button .popup-menu-arrow {
+    #panel .panel-button .popup-menu-hover {
       icon-size: 13px;
       font-size: 13px;
       icon-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3); }

--- a/Flat-Remix-dark/gnome-shell/gnome-shell.css
+++ b/Flat-Remix-dark/gnome-shell/gnome-shell.css
@@ -733,9 +733,7 @@ app menu inside the main app window itself rather than the top bar
       -st-icon-style: symbolic;
       margin-left: 4px;
       margin-right: 4px; }
-    #panel .panel-button .system-status-icon,
-    #panel .panel-button .app-menu-icon > StIcon,
-    #panel .panel-button .popup-menu-arrow {
+    #panel .panel-button .popup-menu-hover {
       icon-size: 13px;
       font-size: 13px;
       icon-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3); }

--- a/Flat-Remix-miami/gnome-shell/gnome-shell.css
+++ b/Flat-Remix-miami/gnome-shell/gnome-shell.css
@@ -732,9 +732,7 @@ app menu inside the main app window itself rather than the top bar
       -st-icon-style: symbolic;
       margin-left: 4px;
       margin-right: 4px; }
-    #panel .panel-button .system-status-icon,
-    #panel .panel-button .app-menu-icon > StIcon,
-    #panel .panel-button .popup-menu-arrow {
+    #panel .panel-button .popup-menu-hover {
       icon-size: 13px;
       font-size: 13px;
       icon-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3); }

--- a/Flat-Remix/gnome-shell/gnome-shell.css
+++ b/Flat-Remix/gnome-shell/gnome-shell.css
@@ -748,9 +748,7 @@ app menu inside the main app window itself rather than the top bar
       -st-icon-style: symbolic;
       margin-left: 4px;
       margin-right: 4px; }
-    #panel .panel-button .system-status-icon,
-    #panel .panel-button .app-menu-icon > StIcon,
-    #panel .panel-button .popup-menu-arrow {
+    #panel .panel-button .popup-menu-hover {
       icon-size: 13px;
       font-size: 13px;
       icon-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3); }


### PR DESCRIPTION
I fixed the bug #36, and it is not crash when leaving full screen.