### PR TITLE
This makes the network manager background black, for Flat-Remix-Darkest-fullPanel

### DIFF
--- a/src/css/Flat-Remix-Darkest-fullPanel.css
+++ b/src/css/Flat-Remix-Darkest-fullPanel.css
@@ -1174,7 +1174,9 @@ StScrollBar {
   icon-size: 2.9em; }
 
 .nm-dialog-scroll-view {
-  border: 0; }
+  border: 0;
+  background-color: black;
+}
 
 .nm-dialog-header {
   font-weight: bold; }


### PR DESCRIPTION
in ubuntu 20.04, when using Flat-Remix-Darkest-fullPanel, the wifi list background is white, and the text is hard to read.

this makes the wifi list background black, for Flat-Remix-Darkest-fullPanel.

i do not know what the ramifications of this change are for older versions of gnome-shell, and i only made changes to this one theme because i have not messed with editing gnome themes before, so was just making this as simple as possible to see if im doing it right. if i am, please let me know and i will adjust the other themes as well.

this does work though

gnome-shell version 3.35.91, ubuntu 20.04