### PR TITLE
Fix visibility of dropdown/pop-menu parent items

### DIFF
--- a/themes/Flat-Remix-Blue-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Blue-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Blue-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Blue-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Blue-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Blue-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Blue-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Blue-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0; 
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Brown-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Brown-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Brown-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Brown-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Brown-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Brown-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Brown-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Brown-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Cyan-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Cyan-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Cyan-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Cyan-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Cyan-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Cyan-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Cyan-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Cyan-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Green-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Green-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Green-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Green-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Green-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Green-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Green-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Green-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Grey-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Grey-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Grey-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Grey-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Grey-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Grey-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Grey-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Grey-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Magenta-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Magenta-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Magenta-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Magenta-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Magenta-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Magenta-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Magenta-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Magenta-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Orange-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Orange-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Orange-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Orange-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Orange-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Orange-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Orange-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Orange-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Red-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Red-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Red-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Red-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Red-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Red-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Red-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Red-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Teal-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Teal-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Teal-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Teal-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Teal-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Teal-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Teal-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Teal-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Violet-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Violet-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Violet-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Violet-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Violet-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Violet-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Violet-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Violet-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-White-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-White-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-White-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-White-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-White-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-White-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-White-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-White-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Yellow-Dark-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Yellow-Dark-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Yellow-Dark/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Yellow-Dark/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #343845 !important; }
   .popup-menu-item:checked {
-    background-color: #3b3f4e !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 #303340;
-    border-radius: 8px 8px 0 0; }
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #3b3f4e !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #414657 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Yellow-Darkest-fullPanel/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Yellow-Darkest-fullPanel/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {

--- a/themes/Flat-Remix-Yellow-Darkest/gnome-shell/gnome-shell.css
+++ b/themes/Flat-Remix-Yellow-Darkest/gnome-shell/gnome-shell.css
@@ -392,11 +392,11 @@ StScrollBar {
     .popup-menu-item:focus:active, .popup-menu-item:hover:active {
       background-color: #141414 !important; }
   .popup-menu-item:checked {
-    background-color: #1c1c1c !important; }
-  .popup-menu-item:checked {
     margin-bottom: 0;
-    box-shadow: inset 0 -1px 0 0 #0f0f0f;
-    border-radius: 8px 8px 0 0; }
+    box-shadow: inset 0 -1px 0 0 #303340;
+    border-radius: 8px 8px 0 0;
+    color: #fcfcfc !important;
+    background-color: #1c1c1c !important; }
     .popup-menu-item:checked:focus, .popup-menu-item:checked:hover {
       background-color: #242424 !important; }
     .popup-menu-item:checked:active {


### PR DESCRIPTION
Currently, using a dark variant, opening a dropdown in a pop menu results in bad visibility of the parent menu item (with a `dark` panel theme) or invisibly (when using a `darkest` theme). It uses the same dark color as the light theme, but on a dark background. Here is a quick example of the current state.


https://user-images.githubusercontent.com/34311583/183301684-aef48322-0ccc-46d8-8097-17a9ef498698.mp4


In contrast, the light theme:

![flat-remix-light](https://user-images.githubusercontent.com/34311583/183301867-f247aa17-59d9-4636-a641-434d8b0859eb.jpg)

**This commit fixes by applying the active item font color to those parent elements.** Result:

![flat-remix-dark](https://user-images.githubusercontent.com/34311583/183301882-1b43196a-06aa-4566-934f-c3c3dd792a61.jpg)

Additionally, a duplicate CSS selector that was declared twice in the block of the added style property was merged. 